### PR TITLE
Update editar-pensamento.component.css - Preparando estilo para o próximo curso

### DIFF
--- a/src/app/componentes/pensamentos/editar-pensamento/editar-pensamento.component.css
+++ b/src/app/componentes/pensamentos/editar-pensamento/editar-pensamento.component.css
@@ -5,6 +5,8 @@
 
 .botao {
   margin: 5px;
+  margin-top: 70px;
+  width: 200px;
 }
 
 .editar-pensamentos {


### PR DESCRIPTION
Para quem copia o CSS no primeiro curso, ao realizar o segundo, e ao implementar o botão desabilitado, o estilo do botão fica quebrado. Essa mudança busca adequar o CSS para ficar igual ao `criar-pensamento.component.css`, e evitar a quebra de estilo.